### PR TITLE
[DESIGN] : 메뉴 네비게이션 바 반응형

### DIFF
--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -1,12 +1,12 @@
 const Footer = () => {
   return (
     <div
-      className={`w-full border-t flex justify-center items-center xl:h-[172px]`}
+      className={`w-full border-t flex justify-center items-center lg:h-[172px]`}
     >
       <div
         className={`w-full flex justify-between 
 				text-primary-white text-[20px]
-				xl:max-w-Xl`}
+			lg:max-w-lg`}
       >
         <div className={`flex flex-col font-Pretendard_Bold`}>
           <p>한동대학교 콘텐츠융합디자인학부</p>

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -26,10 +26,10 @@ const Header = () => {
 
   return (
     <header className="sticky top-0 w-full h-16 flex justify-center items-center border-b backdrop-blur-sm">
-      <div className="w-full flex items-center justify-between xl:max-w-Xl">
+      <div className="w-full flex items-center justify-between lg:max-w-lg sm: ">
         <div>
           <Link to={PATHS.HOME}>
-            <img src={logo} alt="one in christ" className="w-[13.625rem]" />
+            <img src={logo} alt="one in christ" className="lg:w-[13.625rem]" />
           </Link>
         </div>
         <div className="flex items-center gap-x-12">

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -2,6 +2,7 @@ import { Link, useLocation } from "react-router-dom";
 import logo from "../../assets/header/logo.png";
 import Button from "../header/Button";
 import { PATHS } from "../../constants/paths";
+import hamburger from "../../assets/header/hamburger.png";
 
 const button_list = [
   {
@@ -26,13 +27,17 @@ const Header = () => {
 
   return (
     <header className="sticky top-0 w-full h-16 flex justify-center items-center border-b backdrop-blur-sm">
-      <div className="w-full flex items-center justify-between lg:max-w-lg sm: ">
+      <div className="w-full flex items-center justify-between lg:max-w-lg md:w-[90%] sm:w-[90%]">
         <div>
           <Link to={PATHS.HOME}>
-            <img src={logo} alt="one in christ" className="lg:w-[13.625rem]" />
+            <img
+              src={logo}
+              alt="one in christ"
+              className="w-[13.625rem] sm:w-[157px]"
+            />
           </Link>
         </div>
-        <div className="flex items-center gap-x-12">
+        <div className="md:hidden sm:hidden flex items-center gap-x-12">
           {button_list.map((item) => (
             <Link key={item.id} to={item.link}>
               <Button focus={location.pathname === item.link}>
@@ -40,6 +45,9 @@ const Header = () => {
               </Button>
             </Link>
           ))}
+        </div>
+        <div className="lg:hidden">
+          <img src={hamburger} className={`w-[21px]`} />
         </div>
       </div>
     </header>

--- a/src/components/designers/Container.tsx
+++ b/src/components/designers/Container.tsx
@@ -13,7 +13,7 @@ const Container = ({ designer }: Props) => {
         className="h-[69px] border-b
 									flex items-center 
 								text-primary-white text-[18px] 
-									xl:px-6 xl:gap-[220px]
+								lg:px-6 lg:gap-[220px]
 								hover:bg-primary-white hover:text-primary-black
 									cursor-pointer
 									group

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -9,7 +9,7 @@ const Layout = ({ children }: LayoutProps) => {
   return (
     <>
       <Header />
-      <main className="w-full m-0 mx-auto xl:max-w-Xl">{children}</main>
+      <main className="w-full m-0 mx-auto lg:max-w-lg">{children}</main>
       <Footer />
     </>
   );

--- a/src/components/works/WorkList.tsx
+++ b/src/components/works/WorkList.tsx
@@ -13,7 +13,7 @@ const WorkList = ({ category }: Props) => {
   const works: Work[] = WORKS[category] || [];
 
   return (
-    <div className="grid grid-cols-4 gap-[22px] mt-[42px] xl:mb-[206px]">
+    <div className="grid grid-cols-4 gap-[22px] mt-[42px] lg:mb-[206px]">
       {works.map((work) => (
         <Link to={`${PATHS.WORKS}/${category}/${work.id}`}>
           <div

--- a/src/pages/Designer.tsx
+++ b/src/pages/Designer.tsx
@@ -12,7 +12,7 @@ const Designer = () => {
   return (
     <div className={`w-full flex flex-col items-center`}>
       <PageInfo>DESIGNERS</PageInfo>
-      <div className={`w-full flex justify-between xl:pt-[99px] xl:mb-[206px]`}>
+      <div className={`w-full flex justify-between lg:pt-[99px] lg:mb-[206px]`}>
         <DesignerDetail designer={designer} />
         <DesignerWorks designer={designer} />
       </div>

--- a/src/pages/Designers.tsx
+++ b/src/pages/Designers.tsx
@@ -6,7 +6,7 @@ const Designers = () => {
   return (
     <div className={`flex flex-col items-center`}>
       <PageInfo>DESIGNERS</PageInfo>
-      <div className="w-full mt-16 xl:mb-[206px]">
+      <div className="w-full mt-16 lg:mb-[206px]">
         {DESIGNERS.map((designer) => (
           <Container designer={designer} />
         ))}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -14,9 +14,9 @@ export default {
         },
       },
       screens: {
-        sm: { min: "390px", max: "819px" },
-        md: { min: "820px", max: "1023px" },
-        lg: { min: "1080px" },
+        sm: { max: "819px" },
+        md: { min: "820px", max: "1240px" },
+        lg: { min: "1240px" },
       },
       maxWidth: {
         lg: "1240px",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -13,10 +13,13 @@ export default {
           blue: "#2e7ccb",
         },
       },
+      screens: {
+        sm: { min: "390px", max: "819px" },
+        md: { min: "820px", max: "1023px" },
+        lg: { min: "1080px" },
+      },
       maxWidth: {
-        Xl: "1240px",
-        Lg: "930px",
-        Sm: "320px",
+        lg: "1240px",
       },
       fontFamily: {
         Pretendard_Bold: ["Pretendard-Bold"],


### PR DESCRIPTION
### 네비게이션 바 반응형

- 해더에 위치하는 네비게이션 바 screen넓이 조절시 햄버거바로 변경되도록 구현
```typescript
//tailwind.config.js
screens: {
        sm: { max: "819px" },
        md: { min: "820px", max: "1240px" },
        lg: { min: "1240px" },
      },
```
lg의 기준을 1240px까지로 하여 1240px 아래로 넓이가 좁아졌을 경우 햄버거 바가 나타나게끔 구현하였음
```typescript
// Header.tsx
<div className="md:hidden sm:hidden flex items-center gap-x-12">
          {button_list.map((item) => (
            <Link key={item.id} to={item.link}>
              <Button focus={location.pathname === item.link}>
                {item.name}
              </Button>
            </Link>
          ))}
        </div>
        <div className="lg:hidden">
          <img src={hamburger} className={`w-[21px]`} />
        </div>
```

아직 진행되지 않은 부분 - 햄버거바 클릭 이벤트