### PR TITLE
[DESIGN] : pageInfo 컴포넌트 반응형 구현

### DIFF
--- a/src/components/common/PageInfo.tsx
+++ b/src/components/common/PageInfo.tsx
@@ -4,9 +4,17 @@ interface Props {
 
 const PageInfo = ({ children }: Props) => {
   return (
-    <p className="w-screen h-[99px] text-center text-primary-black bg-primary-white font-Organetto_ExtBold text-2xl py-9 sticky top-16">
-      {children}
-    </p>
+    <div
+      className={`flex justify-center items-center
+		w-screen h-[99px] py-9 sticky top-16 bg-primary-white 
+		sm:w-[90%] sm:h-[63px] sm:mt-[19px] sm:relative`}
+    >
+      <p
+        className={`text-center text-primary-black font-Organetto_ExtBold text-2xl sm:text-[15px]`}
+      >
+        {children}
+      </p>
+    </div>
   );
 };
 


### PR DESCRIPTION
## pageInfo 컴포넌트 반응형 구현 (#38)
디자이너 요구사항에 맞게 page별 정보를 나타내는 컴포넌트의 반응형을 구현하였다

## 코드
```typescript
const PageInfo = ({ children }: Props) => {
  return (
    <div
      className={`flex justify-center items-center
		w-screen h-[99px] py-9 sticky top-16 bg-primary-white 
		sm:w-[90%] sm:h-[63px] sm:mt-[19px] sm:relative`}
    >
      <p
        className={`text-center text-primary-black font-Organetto_ExtBold text-2xl sm:text-[15px]`}
      >
        {children}
      </p>
    </div>
  );
};
```
태블릿 뷰도 모바일과 동일하게 가야할 지 고민했지만 데스트탑과 동일한 UI를 가져가고 디자이너와 상의하려고 한다.


### 데스크탑 뷰
<img width="1402" alt="스크린샷 2024-09-21 오후 11 27 31" src="https://github.com/user-attachments/assets/76879e05-d0e1-40be-b3d7-4272189138b5">

### 태블릿뷰
<img width="865" alt="스크린샷 2024-09-21 오후 11 27 56" src="https://github.com/user-attachments/assets/7022d0d8-d9ec-4748-aeb5-d3e2cb0645cd">

### 모바일뷰
<img width="432" alt="스크린샷 2024-09-21 오후 11 28 16" src="https://github.com/user-attachments/assets/77b83556-b9f0-4840-aa42-6cf2fe8157ce">