### PR TITLE
[DESIGN] : 해더, pageInfo 상단 고정 sticky -> fixed

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -74,7 +74,7 @@ const Header = () => {
       </header>
       {toggleOpen && (
         <div
-          className={`lg:hidden fixed z-[100] w-full top-16 bg-primary-black border-b pb-2.5 animate-fadeindown`}
+          className={`lg:hidden fixed z-[100] w-full top-16 bg-primary-black border-b pb-2.5`}
         >
           {button_list.map((item) => (
             <div>

--- a/src/components/common/PageInfo.tsx
+++ b/src/components/common/PageInfo.tsx
@@ -6,7 +6,7 @@ const PageInfo = ({ children }: Props) => {
   return (
     <div
       className={`flex justify-center items-center
-		w-screen h-[99px] py-9 sticky top-16 bg-primary-white 
+		w-screen h-[99px] py-9 fixed top-16 bg-primary-white 
 		sm:w-[90%] sm:h-[63px] sm:mt-[19px] sm:relative`}
     >
       <p

--- a/src/components/works/WorkList.tsx
+++ b/src/components/works/WorkList.tsx
@@ -13,7 +13,7 @@ const WorkList = ({ category }: Props) => {
   const works: Work[] = WORKS[category] || [];
 
   return (
-    <div className="grid grid-cols-4 gap-[22px] mt-[42px] lg:mb-[206px]">
+    <div className="grid grid-cols-4 gap-[22px] mt-[267px] lg:mb-[206px]">
       {works.map((work) => (
         <Link to={`${PATHS.WORKS}/${category}/${work.id}`}>
           <div

--- a/src/pages/Designer.tsx
+++ b/src/pages/Designer.tsx
@@ -12,7 +12,7 @@ const Designer = () => {
   return (
     <div className={`w-full flex flex-col items-center`}>
       <PageInfo>DESIGNERS</PageInfo>
-      <div className={`w-full flex justify-between lg:pt-[99px] lg:mb-[206px]`}>
+      <div className={`w-full flex justify-between mt-[262px] lg:mb-[206px]`}>
         <DesignerDetail designer={designer} />
         <DesignerWorks designer={designer} />
       </div>

--- a/src/pages/Designers.tsx
+++ b/src/pages/Designers.tsx
@@ -6,7 +6,7 @@ const Designers = () => {
   return (
     <div className={`flex flex-col items-center`}>
       <PageInfo>DESIGNERS</PageInfo>
-      <div className="w-full mt-16 lg:mb-[206px]">
+      <div className="w-full mt-[227px] lg:mb-[206px]">
         {DESIGNERS.map((designer) => (
           <Container designer={designer} />
         ))}

--- a/src/pages/Work.tsx
+++ b/src/pages/Work.tsx
@@ -15,7 +15,7 @@ const Work = () => {
   return (
     <div className={`w-full flex flex-col items-center`}>
       <PageInfo>WORKS</PageInfo>
-      <div className={`w-full flex justify-between mt-[118px] mb-[191px]`}>
+      <div className={`w-full flex justify-between mt-[281px] mb-[191px]`}>
         <WorkDesigner work={work} />
         <WorkContents category={category} work={work} />
       </div>

--- a/src/pages/Works.tsx
+++ b/src/pages/Works.tsx
@@ -49,7 +49,7 @@ const Works = () => {
   return (
     <div className="flex flex-col items-center">
       <PageInfo>WORKS</PageInfo>
-      <div className={`sticky top-[177px] flex flex-col items-center`}>
+      <div className={`fixed top-[177px] flex items-center`}>
         <div className="flex justify-between gap-[22px]">
           {category_list.map((item) => (
             <WorksCategoryButton


### PR DESCRIPTION
## 상세 기능
해더, pageInfo 상단 고정구현이 sticky로 되어 있었는데 fixed로 바꾸어주었음
sticky에서는 해당 컴포넌트의 구역이 차지되었는데 fixed되는순간 무시되어 아래에 있던 요소가 위로 올라오는 현상이 생겨
그에 맞는 코드 수정을 해주었음
(#38)