### PR TITLE
[REFACROE] : works 페이지 카테고리 리팩토링

### DIFF
--- a/src/components/works/WorksCategoryButton.tsx
+++ b/src/components/works/WorksCategoryButton.tsx
@@ -1,61 +1,100 @@
 import { WorkCategory } from "../../models/category.model";
+import communication_icon from "../../assets/works/icons/communication_icon.png";
+import service_icon from "../../assets/works/icons/service_icon.png";
+import uxui_icon from "../../assets/works/icons/uxui_icon.png";
+import product_icon from "../../assets/works/icons/product_icon.png";
+
+const category_list = [
+  {
+    id: 1,
+    name: "COMMUNICATION DESIGN",
+    work: "COMMUNICATION" as WorkCategory,
+    imgSrc: communication_icon,
+    imgSize: "w-[35.27px] h-[30.23px]",
+    color: "text-primary-orange",
+  },
+  {
+    id: 2,
+    name: "SERVICE DESIGN",
+    work: "SERVICE" as WorkCategory,
+    imgSrc: service_icon,
+    imgSize: "w-[36.17px] h-[36.17px]",
+    color: "text-primary-red",
+  },
+  {
+    id: 3,
+    name: "UXUI DESIGN",
+    work: "UXUI" as WorkCategory,
+    imgSrc: uxui_icon,
+    imgSize: "w-[41.69px] h-[26.8px]",
+    color: "text-primary-purple",
+  },
+  {
+    id: 4,
+    name: "PRODUCT DESIGN",
+    work: "PRODUCT" as WorkCategory,
+    imgSrc: product_icon,
+    imgSize: "w-[29px] h-[38px]",
+    color: "text-primary-blue",
+  },
+];
 
 interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  categoryName: string;
-  color: string;
-  imgSrc: string;
-  imgSize: string;
   category: string;
   setCategory: React.Dispatch<React.SetStateAction<WorkCategory>>;
 }
 
-const WorksCategoryButton = ({
-  categoryName,
-  color,
-  imgSrc,
-  imgSize,
-  category,
-  setCategory,
-}: Props) => {
+const WorksCategoryButton = ({ category, setCategory }: Props) => {
   return (
-    <button
-      className={
-        "w-[288px] h-[48px] relative flex items-center justify-center overflow-hidden duration-300 transition-all group"
-      }
-      onClick={() => setCategory(categoryName as WorkCategory)}
-    >
-      <div
-        className={`absolute w-[288px] h-[48px] flex justify-center items-center 
-				bg-primary-white
-				font-Organetto_ExtBold text-[15px] ${color}
-				duration-300 transition-all transform ${
-          category === categoryName ? "opacity-100" : "opacity-0"
-        }
-				group-hover:opacity-100
-				group-focus:opacity-100`}
-      >
-        <p
-          className={`duration-500 transition-all transform -translate-y-full ${
-            category === categoryName
-              ? "opacity-100 translate-y-0"
-              : "opacity-0"
-          } 
-					group-hover:translate-y-0 group-hover:opacity-100
-					group-focus:translate-y-0 group-focus:opacity-100`}
-        >
-          {categoryName}
-        </p>
+    <div className={`fixed top-[177px] flex items-center`}>
+      <div className={`flex justify-between gap-[22px]`}>
+        {category_list.map((item) => (
+          <button
+            key={item.id}
+            className={
+              "w-[288px] h-[48px] relative flex items-center justify-center overflow-hidden duration-300 transition-all group"
+            }
+            onClick={() => setCategory(item.work as WorkCategory)}
+          >
+            <div
+              className={`absolute w-[288px] h-[48px] flex justify-center items-center 
+						bg-primary-white
+						font-Organetto_ExtBold text-[15px] ${item.color}
+						duration-300 transition-all transform ${
+              category === item.work ? "opacity-100" : "opacity-0"
+            }
+						group-hover:opacity-100
+						group-focus:opacity-100`}
+            >
+              <p
+                className={`duration-500 transition-all transform -translate-y-full ${
+                  category === item.work
+                    ? "opacity-100 translate-y-0"
+                    : "opacity-0"
+                } 
+							group-hover:translate-y-0 group-hover:opacity-100
+							group-focus:translate-y-0 group-focus:opacity-100`}
+              >
+                {item.work}
+              </p>
+            </div>
+            <div
+              className={`absolute w-[288px] h-[48px] flex justify-center items-center duration-300 transition-all transform translate-y-0 ${
+                category === item.work
+                  ? "opacity-0 translate-y-full"
+                  : "opacity-100"
+              } group-hover:translate-y-full group-hover:opacity-0 group-focus:translate-y-full group-focus:opacity-0`}
+            >
+              <img
+                src={item.imgSrc}
+                alt="category_icon"
+                className={`${item.imgSize}`}
+              />
+            </div>
+          </button>
+        ))}
       </div>
-      <div
-        className={`absolute w-[288px] h-[48px] flex justify-center items-center duration-300 transition-all transform translate-y-0 ${
-          category === categoryName
-            ? "opacity-0 translate-y-full"
-            : "opacity-100"
-        } group-hover:translate-y-full group-hover:opacity-0 group-focus:translate-y-full group-focus:opacity-0`}
-      >
-        <img src={imgSrc} alt="category_icon" className={`${imgSize}`} />
-      </div>
-    </button>
+    </div>
   );
 };
 

--- a/src/pages/Works.tsx
+++ b/src/pages/Works.tsx
@@ -1,47 +1,8 @@
 import WorksCategoryButton from "../components/works/WorksCategoryButton";
-import communication_icon from "../assets/works/icons/communication_icon.png";
-import service_icon from "../assets/works/icons/service_icon.png";
-import uxui_icon from "../assets/works/icons/uxui_icon.png";
-import product_icon from "../assets/works/icons/product_icon.png";
 import { useState } from "react";
 import WorkList from "../components/works/WorkList";
 import { WorkCategory } from "../models/category.model";
 import PageInfo from "../components/common/PageInfo";
-
-const category_list = [
-  {
-    id: 1,
-    name: "COMMUNICATION DESIGN",
-    work: "COMMUNICATION" as WorkCategory,
-    imgSrc: communication_icon,
-    imgSize: "w-[35.27px] h-[30.23px]",
-    color: "text-primary-orange",
-  },
-  {
-    id: 2,
-    name: "SERVICE DESIGN",
-    work: "SERVICE" as WorkCategory,
-    imgSrc: service_icon,
-    imgSize: "w-[36.17px] h-[36.17px]",
-    color: "text-primary-red",
-  },
-  {
-    id: 3,
-    name: "UXUI DESIGN",
-    work: "UXUI" as WorkCategory,
-    imgSrc: uxui_icon,
-    imgSize: "w-[41.69px] h-[26.8px]",
-    color: "text-primary-purple",
-  },
-  {
-    id: 4,
-    name: "PRODUCT DESIGN",
-    work: "PRODUCT" as WorkCategory,
-    imgSrc: product_icon,
-    imgSize: "w-[29px] h-[38px]",
-    color: "text-primary-blue",
-  },
-];
 
 const Works = () => {
   const [category, setCategory] = useState<WorkCategory>("COMMUNICATION");
@@ -49,21 +10,7 @@ const Works = () => {
   return (
     <div className="flex flex-col items-center">
       <PageInfo>WORKS</PageInfo>
-      <div className={`fixed top-[177px] flex items-center`}>
-        <div className="flex justify-between gap-[22px]">
-          {category_list.map((item) => (
-            <WorksCategoryButton
-              key={item.id}
-              categoryName={item.work}
-              color={item.color}
-              imgSrc={item.imgSrc}
-              imgSize={item.imgSize}
-              category={category}
-              setCategory={setCategory}
-            />
-          ))}
-        </div>
-      </div>
+      <WorksCategoryButton category={category} setCategory={setCategory} />
       <WorkList category={category} />
     </div>
   );


### PR DESCRIPTION
## 상세 기능
기존 works페이지에 존재하는 카테고리 메뉴 버튼 컨포넌트의 코드가 works.tsx에서 category_list로 관리되고 있었음
category_list는 굳이 works.tsx에서 관리될 필요가 없는 데이터이기 떄문에 이를 worksCategoryButton 으로 옮겨 주었고, map을 이용한 button 구현역시 해당 파일에서 진행하도록 리팩토링해주었음

## 이전 코드
```typescript
const Works = () => {
  const [category, setCategory] = useState<WorkCategory>("COMMUNICATION");

  return (
    <div className="flex flex-col items-center">
      <PageInfo>WORKS</PageInfo>
      <div className={`fixed top-[177px] flex items-center`}>
        <div className="flex justify-between gap-[22px]">
          {category_list.map((item) => (
            <WorksCategoryButton
              key={item.id}
              categoryName={item.work}
              color={item.color}
              imgSrc={item.imgSrc}
              imgSize={item.imgSize}
              category={category}
              setCategory={setCategory}
            />
          ))}
        </div>
      </div>
      <WorkList category={category} />
    </div>
  );
};
```

## 수정된 코드
```typescript
const Works = () => {
  const [category, setCategory] = useState<WorkCategory>("COMMUNICATION");

  return (
    <div className="flex flex-col items-center">
      <PageInfo>WORKS</PageInfo>
      <WorksCategoryButton category={category} setCategory={setCategory} />
      <WorkList category={category} />
    </div>
  );
};
```