### PR TITLE
[DESIGN] : 작품 상세페이지 반응형 구현

### DIFF
--- a/src/components/common/PageInfo.tsx
+++ b/src/components/common/PageInfo.tsx
@@ -6,8 +6,8 @@ const PageInfo = ({ children }: Props) => {
   return (
     <div
       className={`flex justify-center items-center
-		w-screen h-[99px] py-9 fixed top-16 bg-primary-white 
-		sm:w-[90%] sm:h-[63px] sm:mt-[19px] sm:relative`}
+		w-screen h-[99px] lg:fixed md:fixed top-16 bg-primary-white 
+		sm:w-[90%] sm:h-[63px] sm:mt-[19px] absolute`}
     >
       <p
         className={`text-center text-primary-black font-Organetto_ExtBold text-2xl sm:text-[15px]`}

--- a/src/components/works/WorkContents.tsx
+++ b/src/components/works/WorkContents.tsx
@@ -8,9 +8,11 @@ interface Props {
 
 const WorkContents = ({ category, work }: Props) => {
   return (
-    <div className={`flex flex-col text-primary-white justify-between`}>
+    <div
+      className={`w-[687px] md:w-[50%] sm:w-full flex flex-col text-primary-white lg:justify-between md:gap-[40px] sm:gap-[6px]`}
+    >
       <p
-        className={`font-Menda_Medium text-[22px] ${
+        className={`font-Menda_Medium sm:text-[12px] md:text-[19px] text-[22px] ${
           category === "COMMUNICATION"
             ? "text-primary-orange"
             : category === "SERVICE"
@@ -20,11 +22,16 @@ const WorkContents = ({ category, work }: Props) => {
                 : "text-primary-blue"
         }`}
       >{`${category} DESIGN`}</p>
+
       <div>
-        <p className={`font-Pretendard_Bold text-[33px] mb-[14px]`}>
+        <p
+          className={`font-Pretendard_Bold sm:text-[22px] md:text-[27px] text-[33px] mb-[14px]`}
+        >
           {work?.title}
         </p>
-        <p className={`w-[687px] font-Pretendard_Regular text-[17px]`}>
+        <p
+          className={`font-Pretendard_Regular sm:text-[12px] md:text-[14px] text-[17px]`}
+        >
           작품을 소개하는 글을 적어주세요. 작품을 소개하는 글을 적어주세요.
           작품을 소개하는 글을 적어주세요. 작품을 소개하는 글을 적어주세요.
           작품을 소개하는 글을 적어주세요. 작품을 소개하는 글을 적어주세요.

--- a/src/components/works/WorkDesigner.tsx
+++ b/src/components/works/WorkDesigner.tsx
@@ -1,4 +1,6 @@
 import { Work } from "../../models/work.model";
+import designer_alone from "../../assets/works/project/test/designer_alone.png"; // test
+import designer_group from "../../assets/works/project/test/designer_group.png"; // test
 
 interface Props {
   work: Work | null;
@@ -8,36 +10,67 @@ const WorkDesigner = ({ work }: Props) => {
   return (
     <>
       {work?.designer.length === 1 ? (
-        <div className={`flex gap-6 items-end`}>
-          <div className={`w-[192px] h-[272px] border border-white`}></div>
-          <div className={`flex flex-col gap-1 text-primary-white items-start`}>
-            <div className={`flex gap-[7px] font-Pretendard_Bold items-end`}>
-              <p className={`text-[28px]`}>{work.designer[0].nameKo}</p>
-              <p className={`text-[19px]`}>영어이름</p>
+        <div className={`md:w-[45%]`}>
+          <div className={`flex gap-6 items-end`}>
+            {/* TODO: test 이미지  */}
+            <img
+              src={designer_alone}
+              className={`w-[192px] sm:w-[125.69px] md:w-[50%]`}
+            />
+            <div
+              className={`flex flex-col gap-1 text-primary-white items-start`}
+            >
+              <div className={`flex gap-[7px] font-Pretendard_Bold items-end`}>
+                <p className={`sm:text-[18px] md:text-[26px] text-[28px]`}>
+                  {work.designer[0].nameKo}
+                </p>
+                <p className={`sm:text-[12px] md:text-[17px] text-[19px]`}>
+                  영어이름
+                </p>
+              </div>
+              <p
+                className={`font-Pretendard_Regular sm:text-[11px] md:text-[15px] text-[17px]`}
+              >
+                example.com
+              </p>
             </div>
-            <p className={`font-Pretendard_Regular text-[17px]`}>example.com</p>
           </div>
         </div>
       ) : (
         <div
-          className={`flex flex-col gap-[20px] font-Pretendard_Bold text-primary-white`}
+          className={`flex flex-col gap-[20px] w-[411px] md:w-[40%] sm:w-full font-Pretendard_Bold text-primary-white`}
         >
-          <div className={`w-[411px] h-[227px] border`} />
-          <div className={`flex gap-[27px] items-baseline`}>
-            <p className={`text-[28px]`}>{work?.teamName}</p>
-            {/* TODO: team name 하드코딩 */}
-            <p className={`text-19px]`}>team name</p>
-          </div>
-          <div className={`grid grid-cols-2`}>
-            {work?.designer.map((item) => (
-              <div className={`flex gap-[19px]`}>
-                <p className={`text-[19px]`}>{item.nameKo}</p>
-                {/* TODO: email 하드코딩 */}
-                <p className={`text-[15px] font-Pretendard_Regular`}>
-                  email.com
-                </p>
-              </div>
-            ))}
+          {/* TODO: test 이미지  */}
+          <img src={designer_group} className={`w-full`} />
+          <div className={`sm:flex justify-between`}>
+            <div className={`flex gap-[27px] items-baseline`}>
+              <p className={`sm:text-[18px] md:text-[26px] text-[28px]`}>
+                {work?.teamName}
+              </p>
+              {/* TODO: team name 하드코딩 */}
+              <p className={`sm:text-[12px] md:text-[17px] text-[19px]`}>
+                team name
+              </p>
+            </div>
+            <div
+              className={`grid grid-cols-2 gap-[7px] sm:flex sm:flex-col sm:gap-[6px]`}
+            >
+              {work?.designer.map((item) => (
+                <div
+                  className={`flex gap-[19px] items-center w-[250px] sm:gap-[13px] sm:w-auto`}
+                >
+                  <p className={`sm:text-[11px] md:text-[15px] text-[19px]`}>
+                    {item.nameKo}
+                  </p>
+                  {/* TODO: email 하드코딩 */}
+                  <p
+                    className={`sm:text-[11px] md:text-[15px] text-[15px] font-Pretendard_Regular`}
+                  >
+                    email.com
+                  </p>
+                </div>
+              ))}
+            </div>
           </div>
         </div>
       )}

--- a/src/pages/Work.tsx
+++ b/src/pages/Work.tsx
@@ -15,7 +15,9 @@ const Work = () => {
   return (
     <div className={`w-full flex flex-col items-center`}>
       <PageInfo>WORKS</PageInfo>
-      <div className={`w-full flex justify-between mt-[281px] mb-[191px]`}>
+      <div
+        className={`w-[90%] lg:w-full flex sm:flex-col justify-between sm:gap-[34px] mt-[281px] md:mt-[230px] sm:mt-[165px] mb-[191px]`}
+      >
         <WorkDesigner work={work} />
         <WorkContents category={category} work={work} />
       </div>


### PR DESCRIPTION
## 기능 상세
- 작품 상세페이지 반응형 구현
- 개인 작품과 단체 작품의 레이아웃이 달라 각각 반응형을 구현해주었음
close #50 

## 개인작품 (모바일, 태블릿, 데스크탑)
![스크린샷 2024-09-23 오전 3 36 12](https://github.com/user-attachments/assets/dec8c61b-917f-4f62-9018-b59739e8bd88)
![스크린샷 2024-09-23 오전 3 36 34](https://github.com/user-attachments/assets/70b19f6d-19ff-435c-bb38-81f9fcaee1d4)
![스크린샷 2024-09-23 오전 3 36 49](https://github.com/user-attachments/assets/4c160a51-8fcc-4701-ae3c-d3d6a47398eb)

## 단체작품 (모바일, 태블릿, 데스크탑)
![스크린샷 2024-09-23 오전 3 37 21](https://github.com/user-attachments/assets/f129e021-fd3c-4aa6-b80f-5d771465cc37)
![스크린샷 2024-09-23 오전 3 37 37](https://github.com/user-attachments/assets/b7da030f-0dc1-4fe2-8462-ce5deb09427d)
![스크린샷 2024-09-23 오전 3 38 02](https://github.com/user-attachments/assets/e6193a6a-4f81-4f42-b41f-ed972d3836f1)
