### PR TITLE
[FIX] : z-index 설정으로 이미지 삽입 사이드 이펙트 해결

### DIFF
--- a/src/components/common/PageInfo.tsx
+++ b/src/components/common/PageInfo.tsx
@@ -6,8 +6,8 @@ const PageInfo = ({ children }: Props) => {
   return (
     <div
       className={`flex justify-center items-center
-		w-screen h-[99px] lg:fixed md:fixed top-16 bg-primary-white 
-		sm:w-[90%] sm:h-[63px] sm:mt-[19px] absolute`}
+		w-screen h-[99px] lg:fixed md:fixed z-50 top-16 bg-primary-white 
+		sm:w-[90%] sm:h-[63px] sm:mt-[19px]`}
     >
       <p
         className={`text-center text-primary-black font-Organetto_ExtBold text-2xl sm:text-[15px]`}

--- a/src/components/works/WorksCategoryButton.tsx
+++ b/src/components/works/WorksCategoryButton.tsx
@@ -68,7 +68,7 @@ const WorksCategoryButton = ({ category, setCategory }: Props) => {
     <>
       {/* lg 데스크탑 뷰 카테고리 메뉴 */}
       <div
-        className={`md:hidden sm:hidden fixed top-[177px] flex items-center`}
+        className={`md:hidden sm:hidden fixed z-50 top-[177px] flex items-center`}
       >
         <div className={`flex justify-between gap-[22px]`}>
           {category_list.map((item) => (


### PR DESCRIPTION
## 상세 구현
- 이미지 삽입하기 전에는 z-index 없이도 요소들이 pageInfo나 waroksCategoryButton 밑으로 잘 들어갔는데 이미지 삽입 후 이미지가 해당 컴포넌트들 위로 올라오는 현상이 발생하였다.
- 따라서 z-index를 넣어 pagiInfo와 waroksCategoryButton를 상위에 그리도록 설정하였다

close #59 