### PR TITLE
[DESIGN] : 디자이너 페이지 LIST 수정사항 반영

### DIFF
--- a/src/components/designers/DesignerList.tsx
+++ b/src/components/designers/DesignerList.tsx
@@ -6,7 +6,7 @@ interface Props {
   designer: DesingerDetailInfo;
 }
 
-const Container = ({ designer }: Props) => {
+const DesignerList = ({ designer }: Props) => {
   return (
     <Link to={`${PATHS.DESIGNERS}/${designer.id}`}>
       <div
@@ -29,4 +29,4 @@ const Container = ({ designer }: Props) => {
   );
 };
 
-export default Container;
+export default DesignerList;

--- a/src/components/designers/DesignerList.tsx
+++ b/src/components/designers/DesignerList.tsx
@@ -1,6 +1,7 @@
 import { Link } from "react-router-dom";
 import { PATHS } from "../../constants/paths";
 import { DesingerDetailInfo } from "../../models/designer.model";
+import designer_work from "../../assets/works/project/test/designer_work.png";
 
 interface Props {
   designer: DesingerDetailInfo;
@@ -13,17 +14,23 @@ const DesignerList = ({ designer }: Props) => {
         className="h-[69px] border-b
 									flex items-center 
 								text-primary-white text-[18px] 
-								lg:px-6 lg:gap-[220px]
+								lg:px-6 lg:gap-[184px]
 								hover:bg-primary-white hover:text-primary-black
 									cursor-pointer
 									group
 									"
       >
         <p className="font-Pretendard_Regular">{designer.nameKo}</p>
-        <p className="font-TT_Firs_Light">{designer.nameEng}</p>
-        <div className="hidden w-[303px] h-[430px] group-hover:block absolute top-[393px] right-[400px] bg-primary-blue">
-          {designer.nameKo}
+        <div className={`flex gap-[20px]`}>
+          {designer.works.map((work) => (
+            <p className="font-TT_Firs_Light">{work.category} Design</p>
+          ))}
         </div>
+
+        <img
+          src={designer_work}
+          className="hidden w-[416px] group-hover:block group-hover:fixed absolute top-[327px] right-[300px]"
+        />
       </div>
     </Link>
   );

--- a/src/constants/designers.ts
+++ b/src/constants/designers.ts
@@ -12,7 +12,7 @@ export const DESIGNERS = [
     works: [
       {
         work: WORKS.UXUI,
-        category: "UXUI",
+        category: "UX",
         worksId: 3,
       },
     ],
@@ -28,12 +28,12 @@ export const DESIGNERS = [
     works: [
       {
         work: WORKS.COMMUNICATION,
-        category: "COMMUNICATION",
+        category: "Communication",
         worksId: 8,
       },
       {
         work: WORKS.SERVICE,
-        category: "SERVICE",
+        category: "Service",
         worksId: 8,
       },
     ],

--- a/src/models/category.model.ts
+++ b/src/models/category.model.ts
@@ -1,1 +1,9 @@
-export type WorkCategory = "COMMUNICATION" | "SERVICE" | "UXUI" | "PRODUCT";
+export type WorkCategory =
+  | "COMMUNICATION"
+  | "SERVICE"
+  | "UXUI"
+  | "PRODUCT"
+  | "Communication"
+  | "Service"
+  | "UX"
+  | "Product";

--- a/src/pages/Designers.tsx
+++ b/src/pages/Designers.tsx
@@ -1,5 +1,5 @@
 import PageInfo from "../components/common/PageInfo";
-import Container from "../components/designers/Container";
+import DesignerList from "../components/designers/DesignerList";
 import { DESIGNERS } from "../constants/designers";
 
 const Designers = () => {
@@ -8,7 +8,7 @@ const Designers = () => {
       <PageInfo>DESIGNERS</PageInfo>
       <div className="w-full mt-[227px] lg:mb-[206px]">
         {DESIGNERS.map((designer) => (
-          <Container designer={designer} />
+          <DesignerList designer={designer} />
         ))}
       </div>
     </div>


### PR DESCRIPTION
## 상세 구현
- 디자이너 페이지 리스트의 수정 사항을 반영

## 결과
<img width="1565" alt="스크린샷 2024-09-25 오후 9 20 40" src="https://github.com/user-attachments/assets/a8551c5d-7896-4c86-8813-3cd3af134d89">
<img width="1509" alt="스크린샷 2024-09-25 오후 9 20 52" src="https://github.com/user-attachments/assets/1375d3f8-38f8-4120-bffb-54afd8d2e036">
close #67 