### PR TITLE
[FEAT] : 페이지 이동시 스크롤 위로 이동

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,11 +1,19 @@
+import { useLocation } from "react-router";
 import Footer from "../common/Footer";
 import Header from "../common/Header";
+import { useEffect } from "react";
 
 interface LayoutProps {
   children: React.ReactNode;
 }
 
 const Layout = ({ children }: LayoutProps) => {
+  const location = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [location]);
+
   return (
     <>
       <Header />


### PR DESCRIPTION
페이지 이동시 스크롤의 영향을 받아 해당 스크롤로만 이동하는 문제가 있어서 스크롤을 상단으로 배치시키는 작업을 해주었음
```typescript
  const location = useLocation();

  useEffect(() => {
    window.scrollTo(0, 0);
  }, [location]);
```
close #88