### PR TITLE
[FEAT] : work 스크롤시 PageInfo 안보이도록 구현

### DIFF
--- a/src/pages/Work.tsx
+++ b/src/pages/Work.tsx
@@ -5,6 +5,7 @@ import { WorkCategory } from "../models/category.model";
 import WorkDesigner from "../components/works/WorkDesigner";
 import WorkContents from "../components/works/WorkContents";
 import Creation from "../components/works/Creation";
+import { motion } from "framer-motion";
 
 const Work = () => {
   const params = useParams();
@@ -15,7 +16,13 @@ const Work = () => {
 
   return (
     <div className={`w-full flex flex-col items-center`}>
-      <PageInfo>WORKS</PageInfo>
+      <motion.div
+        initial={{ opacity: 0 }}
+        whileInView={{ opacity: 1 }}
+        className={`flex justify-center`}
+      >
+        <PageInfo>WORKS</PageInfo>
+      </motion.div>
       <div
         className={`w-[90%] lg:w-full flex sm:flex-col justify-between sm:gap-[34px] mt-[281px] md:mt-[230px] sm:mt-[165px] mb-[191px]`}
       >


### PR DESCRIPTION
## 상세 구현
- 기존에는 PageInfo가 있어서 work 작품을 보는데 방해되는 요소가 컸기 때문에 해당 부분을 업애는 방향으로 디자이너에게 제안했다.
- 이에 pageInfo는 work 페이지에서는 스크롤 내릴 시 보이지 않는다.
- framer-motion을 사용하여 구현
```typescript
<motion.div
        initial={{ opacity: 0 }}
        whileInView={{ opacity: 1 }}
        className={`flex justify-center`}
      >
```

close #109 